### PR TITLE
Add support for turning off SSL validation for On-Prem

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Configurable parameters in `kubewatcher.yaml`:
 
 * `SDC_ADMIN_TOKEN` - The Sysdig Cloud API Token of an admin user in your environment. This is needed because only admin users are capable of creating and configuring Teams.
 * `SDC_URL` (optional) - The URL you use to access Sysdig Cloud. The default is set for SaaS users, but will need to be changed if you have an [on-premise install](https://support.sysdigcloud.com/hc/en-us/articles/206519903-On-Premises-Installation-Guide).
+* `SDC_SSL_VERIFY` - Whether SSL cert verification will be attempted when Kubewatcher connects to `SDC_URL`. SaaS users should leave at its default of `"true"`, while [on-premise installs](https://support.sysdigcloud.com/hc/en-us/articles/206519903-On-Premises-Installation-Guide) will typically need to set this to `"false"`.
 * `TEAM_PREFIX` (optional) - A string that will be prepended to the names of Teams and Notification Channels automatically created by Kubewatcher. This will make them easier to identify in the Sysdig Cloud UI.
 
 From inside the pod where it runs, Kubewatcher will automatically attempt to contact the Kubernetes API server at the DNS name `kubernetes` using the credential and certificate bundle as described in the docs [here](https://kubernetes.io/docs/user-guide/accessing-the-cluster/#accessing-the-api-from-a-pod).

--- a/kubewatcher.yaml
+++ b/kubewatcher.yaml
@@ -11,12 +11,14 @@ spec:
     spec:
       containers:
       - name: kubewatcher
-        image: sysdig/kubewatcher:0.1.0
+        image: sysdig/kubewatcher:0.1.1
         env:
         - name: SDC_ADMIN_TOKEN
           value: abcdef01-2345-6789-abcd-ef0123456789
         - name: SDC_URL
           value:
+        - name: SDC_SSL_VERIFY
+          value: "true"
         - name: KUBE_URL
           value:
         - name: TEAM_PREFIX


### PR DESCRIPTION
The [Python SDC client](https://github.com/draios/python-sdc-client) was recently updated to include the option to disable SSL cert validation, which is going to be typical for most [On-Prem installs](https://support.sysdigcloud.com/hc/en-us/articles/206519903-On-Premises-Installation-Guide). Earlier today I put a new release of the Python SDC client onto PyPI that includes that option, built a new Kubewatcher container that bundles with it, and put that container on Docker Hub. This PR just updates the YAML for creating a Kubewatcher Deployment so that it has the tag for that new container and also references the env variable that affects the setting. I tested it out by creating two successful Kubewatcher deployments: One that  connected to SaaS (with SSL verify enabled) and one that connected to an On-Prem install (and I needed to set SSL verify to "false" for it to work).