### PR TITLE
Add flag for IBM Cloud Sysdig and update the team management for IBM.

### DIFF
--- a/kube_obj_parser.py
+++ b/kube_obj_parser.py
@@ -9,6 +9,9 @@ sys.path.insert(0, '../python-sdc-client')
 from sdcclient import SdcClient
 import time
 from time import gmtime, strftime
+# fix the 'InsecureRequestWarning' error
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 TEAM_NOT_EXISTING_ERR = 'Could not find team'
 USER_NOT_FOUND_ERR = 'User not found'
@@ -404,22 +407,27 @@ class KubeURLParser(object):
                         continue
 
     def _kube_get(self, url, endpoint):
+        headers = {}
+        k8s_cert_existed = False
+        if os.path.exists(K8S_BEARER_TOKEN_FILE_NAME) and os.stat(K8S_BEARER_TOKEN_FILE_NAME).st_size > 0:
+            with open(K8S_BEARER_TOKEN_FILE_NAME, 'r') as tokenfile:
+                headers = {'Authorization': 'Bearer ' + tokenfile.read() }
+        else:
+            Logger.log('Connect Kubernetes API server failed: Could not find bearer token at ' + K8S_BEARER_TOKEN_FILE_NAME + '. Exiting.')
+            sys.exit(1)
+        if os.path.exists(K8S_CA_CRT_FILE_NAME) and os.stat(K8S_CA_CRT_FILE_NAME).st_size > 0:
+            k8s_cert_existed = True
+
         if url:
-            return requests.get(url + endpoint)
+            if k8s_cert_existed:
+                return requests.get(url + endpoint, verify = K8S_CA_CRT_FILE_NAME, headers=headers)
         else:
             kube_service_port = os.getenv('KUBERNETES_SERVICE_PORT_HTTPS')
             if kube_service_port is None:
                 Logger.log('Autodiscover of Kubernetes API server failed:' +
                            'Could not find env variable KUBERNETES_SERVICE_PORT_HTTPS. Exiting.')
                 sys.exit(1)
-            if os.path.exists(K8S_BEARER_TOKEN_FILE_NAME) and os.stat(K8S_BEARER_TOKEN_FILE_NAME).st_size > 0:
-                with open(K8S_BEARER_TOKEN_FILE_NAME, 'r') as tokenfile:
-                    headers = {'Authorization': 'Bearer ' + tokenfile.read() }
-            else:
-                Logger.log('Autodiscover of Kubernetes API server failed: Could not find bearer token at ' +
-                           K8S_BEARER_TOKEN_FILE_NAME + '. Exiting.')
-                sys.exit(1)
-            if os.path.exists(K8S_CA_CRT_FILE_NAME) and os.stat(K8S_CA_CRT_FILE_NAME).st_size > 0:
+            if k8s_cert_existed:
                 return requests.get('https://' + K8S_DEFAULT_DNS_NAME + ':' + kube_service_port + endpoint,
                                     verify = K8S_CA_CRT_FILE_NAME,
                                     headers=headers)

--- a/kube_obj_parser.py
+++ b/kube_obj_parser.py
@@ -9,9 +9,6 @@ sys.path.insert(0, '../python-sdc-client')
 from sdcclient import SdcClient
 import time
 from time import gmtime, strftime
-# fix the 'InsecureRequestWarning' error
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
-requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 TEAM_NOT_EXISTING_ERR = 'Could not find team'
 USER_NOT_FOUND_ERR = 'User not found'
@@ -409,9 +406,15 @@ class KubeURLParser(object):
     def _kube_get(self, url, endpoint):
         headers = {}
         k8s_cert_existed = False
+        
         if os.path.exists(K8S_BEARER_TOKEN_FILE_NAME) and os.stat(K8S_BEARER_TOKEN_FILE_NAME).st_size > 0:
-            with open(K8S_BEARER_TOKEN_FILE_NAME, 'r') as tokenfile:
-                headers = {'Authorization': 'Bearer ' + tokenfile.read() }
+            try:
+                with open(K8S_BEARER_TOKEN_FILE_NAME, 'r') as tokenfile:
+                    headers = {'Authorization': 'Bearer ' + tokenfile.read() }
+            except:
+                Logger.log(sys.exc_info()[1], 'error')
+                traceback.print_exc()
+                sys.exit(1)
         else:
             Logger.log('Connect Kubernetes API server failed: Could not find bearer token at ' + K8S_BEARER_TOKEN_FILE_NAME + '. Exiting.')
             sys.exit(1)

--- a/kubewatcher.py
+++ b/kubewatcher.py
@@ -6,6 +6,9 @@ import time
 import traceback
 from sdcclient import SdcClient
 from kube_obj_parser import KubeObjParser, KubeURLParser, Logger
+# fix the 'InsecureRequestWarning' error
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 def log(str, severity='info'):
     Logger.log(str, severity)

--- a/kubewatcher.py
+++ b/kubewatcher.py
@@ -34,6 +34,10 @@ KUBE_URL = os.getenv('KUBE_URL')
 if not KUBE_URL:
     log('Did not find Kubernetes API server URL at env variable "KUBE_URL". Will attempt to autodiscover.', 'info')
 
+IBM_ENABLED = os.getenv('IBM_ENABLED')
+if not IBM_ENABLED or IBM_ENABLED == 'false':
+    log('Using the Sysdig native instance', 'info')
+
 #
 # Instantiate the customer admin SDC client
 #

--- a/kubewatcher.yaml
+++ b/kubewatcher.yaml
@@ -23,3 +23,5 @@ spec:
           value:
         - name: TEAM_PREFIX
           value: KW-
+        - name: IBM_ENABLED
+          value: "false"


### PR DESCRIPTION
 We found there are some different sysdig API response (i.e. the user email, dashboards ) in IBM sysdig and draios version. 
For example:
1. `/api/users`
In IBM sysdig, the `username` in the API response is not the user email address but the value generated by IBM.
```
"users": [{
		"termsAndConditions": true,
		"timezone": "+00:00",
		"pictureUrl": "http://www.gravatar.com/avatar/9cfee1e1134b8a4c82883efc29ec4222",
		"customer": {
			"id": 22210,
			"name": "******",
			"accessKey": "******"
		},
		"oauth": false,
		"properties": {
			"resetPassword": true,
			"OpenID Connect profile id": "aqan@cn.ibm.com",
			"iamId": "IBMid-310002BDRD",
			"openid": true,
			"IbmJwtProfileId": "******",
			"user_email_alias": "<USER_EMAIL>",
			"IbmJwt": true,
			"has_been_invited": true
		},
		"resetPassword": true,
		"additionalRoles": [],
		"teamRoles": [{
			"teamId": 10051,
			"teamName": "Monitor Operations",
			"teamTheme": "#7BB0B2",
			"userId": 10713,
			"userName": "d869e779aa******_ibmid-310002bdrd@ibm.com",
			"role": "ROLE_TEAM_MANAGER",
			"admin": true
		}],
		"lastUpdated": 1574152543000,
		"accessKey": "*****",
		"version": 15,
		"id": 10713,
		"enabled": true,
		"lastSeen": 1574052462000,
		"products": ["SDC"],
		"username": "d869e779aa*******_ibmid-310002bdrd@ibm.com",
		"status": "confirmed",
		"systemRole": "ROLE_CUSTOMER",
		"firstName": "***",
		"lastName": "**",
		"dateCreated": 1573892567000
	}
```
2. `/api/teams`
In IBM sysdig , there are no `userRoles` in the response but just the `"userCount":`:
```
"teams": [{
		"version": 0,
		"description": "Immutable Monitor team with full visibility",
		"name": "Monitor Operations",
		"default": true,
		"properties": {},
		"id": 10051,
		"origin": "SYSDIG",
		"show": "host",
		"entryPoint": {
			"module": "Explore"
		},
		"theme": "#7BB0B2",
		"products": ["SDC"],
		"customerId": 22210,
		"dateCreated": 1573888882000,
		"lastUpdated": 1573888882000,
		"immutable": true,
		"canUseCustomEvents": true,
		"canUseAwsMetrics": true,
		"userCount": 1,
		"canUseSysdigCapture": true
	}]
```
3. `/api/v2/dashboards`
In both IBM sysdig and draios version, there are no `isShared` value but `shared`, also no `annotations` values.
```
{
               "customerId": 26132,
		"userId": 31929,
		"domain": null,   
                 *********** 
           
                "version": 1,
		"shared": true,
		"schema": 2,
		"name": "Overview by Process",
		"id": 135835,
		"public": false,
		"publicToken": null,
		"teamId": 23724,
		"autoCreated": true,
		"createdOn": 1572920429000,
		"username": "xxxx",
		"modifiedOn": 1572920429000,
		"favorite": false
    }
```

4. the args of the function `create_dashboard_from_view` is not correct in `kube_obj_parser.py`. https://github.com/draios/sysdig-kube-watcher/blob/068e6599b5ad02fa2dc7f6266613026c5a4f26c6/kube_obj_parser.py#L342

The correct function is here and last argument is  boolean type.

"_def create_dashboard_from_view(self, newdashname, viewname, filter, shared=False, public=False):_"

https://github.com/draios/python-sdc-client/blob/9b6a7fba636dbf0a73d65b59ceec4d7f16af97bc/sdcclient/_monitor.py#L645